### PR TITLE
[FIX] Parsing CreatedNode (trustline) with non-zero starting balance

### DIFF
--- a/transactionparser/package.json
+++ b/transactionparser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-lib-transactionparser",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Parses transaction objects to a higher-level view",
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/.bin/istanbul test ./node_modules/.bin/_mocha -- --reporter spec test/*-test.js",

--- a/transactionparser/src/balancechanges.js
+++ b/transactionparser/src/balancechanges.js
@@ -53,12 +53,20 @@ function parseTrustlineBalanceChanges(node) {
   if(balanceChange.isZero()) {
     return null;
   }
+
+  /*
+   * A trustline can be created with a non-zero starting balance
+   * If an offer is placed to acquire an asset with no existing trustline,
+   * the trustline can be created when the ofer is taken.
+   */
+  var fields = _.isEmpty(node.newFields) ? node.finalFields : node.newFields;
+
   // the balance is always from low node's perspective
   var change = {
-    address: node.finalFields.LowLimit.issuer,
+    address: fields.LowLimit.issuer,
     balance_change: {
-      counterparty: node.finalFields.HighLimit.issuer,
-      currency: node.finalFields.Balance.currency,
+      counterparty: fields.HighLimit.issuer,
+      currency: fields.Balance.currency,
       value: balanceChange.toString()
     }
   };

--- a/transactionparser/test/balancechanges-test.js
+++ b/transactionparser/test/balancechanges-test.js
@@ -109,8 +109,29 @@ var setTrustlineBalanceChanges2 = {
   ]
 };
 
-// Set trust limit to 100 USD on rLDY when it has no trustline
-var createTrustlineBalanceChanges = setTrustlineBalanceChanges;
+// Set trust limit to 100 USD with balance of 10 USD on rLDY when it has no trustline
+var createTrustlineBalanceChanges = {
+  rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K: [
+    {
+      counterparty: "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      currency: "USD",
+      value: "10"
+    },
+    {
+      counterparty: "",
+      currency: "XRP",
+      value: "-0.012"
+    }
+  ],
+  rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q: [
+    {
+      counterparty: "rLDYrujdKUfVx28T9vRDAbyJ7G2WVXKo4K",
+      currency: "USD",
+      value: "-10"
+    }
+  ]
+};
+
 
 // Pay 0.02 USD from rLDY to rKmB when rLDY has a trust limit of 0
 // for USD, but still has a balance of 0.02 USD; which closes the trustline

--- a/transactionparser/test/fixtures/trustline-create.json
+++ b/transactionparser/test/fixtures/trustline-create.json
@@ -47,7 +47,7 @@
             "Balance": {
               "currency": "USD",
               "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
-              "value": "0"
+              "value": "10"
             },
             "Flags": 65536,
             "HighLimit": {


### PR DESCRIPTION
- Bump to v0.3.1