### PR TITLE
ripple-lib-value: migrate to new bignumber.js APIs introduced since v6

### DIFF
--- a/value/src/iouvalue.js
+++ b/value/src/iouvalue.js
@@ -16,7 +16,7 @@ class IOUValue extends Value {
   constructor(value: string | BigNumber, roundingMode: ?number = null,
   base: ?number = null) {
 
-    super(new BigNumber(value, base).toDigits(16, roundingMode));
+    super(new BigNumber(value, base).precision(16, roundingMode));
   }
 
   multiply(multiplicand: Value) {
@@ -37,7 +37,7 @@ class IOUValue extends Value {
   }
 
   negate() {
-    return new IOUValue(this._value.neg());
+    return new IOUValue(this._value.negated());
   }
 
   _canonicalize(value) {
@@ -49,7 +49,7 @@ class IOUValue extends Value {
 
   equals(comparator) {
     return (comparator instanceof IOUValue)
-      && this._value.equals(comparator._value);
+      && this._value.isEqualTo(comparator._value);
   }
 }
 

--- a/value/src/value.js
+++ b/value/src/value.js
@@ -56,12 +56,12 @@ class Value {
   }
 
   invert() {
-    const result = (new BigNumber(this._value)).toPower(-1);
+    const result = (new BigNumber(this._value)).exponentiatedBy(-1);
     return this._canonicalize(result);
   }
 
   round(decimalPlaces: number, roundingMode: number) {
-    const result = this._value.round(decimalPlaces, roundingMode);
+    const result = this._value.decimalPlaces(decimalPlaces, roundingMode);
     return this._canonicalize(result);
   }
 
@@ -91,12 +91,12 @@ class Value {
 
   greaterThan(comparator: Value) {
     assert(this.constructor === comparator.constructor);
-    return this._value.greaterThan(comparator._value);
+    return this._value.isGreaterThan(comparator._value);
   }
 
   lessThan(comparator: Value) {
     assert(this.constructor === comparator.constructor);
-    return this._value.lessThan(comparator._value);
+    return this._value.isLessThan(comparator._value);
   }
 
   comparedTo(comparator: Value) {

--- a/value/src/xrpvalue.js
+++ b/value/src/xrpvalue.js
@@ -40,19 +40,19 @@ class XRPValue extends Value {
   }
 
   negate() {
-    return new XRPValue(this._value.neg());
+    return new XRPValue(this._value.negated());
   }
 
   _canonicalize(value) {
     if (value.isNaN()) {
       throw new Error('Invalid result');
     }
-    return new XRPValue(value.round(6, BigNumber.ROUND_DOWN));
+    return new XRPValue(value.decimalPlaces(6, BigNumber.ROUND_DOWN));
   }
 
   equals(comparator) {
     return (comparator instanceof XRPValue)
-      && this._value.equals(comparator._value);
+      && this._value.isEqualTo(comparator._value);
   }
 }
 


### PR DESCRIPTION
See https://github.com/MikeMcl/bignumber.js/blob/master/CHANGELOG.md#600

A little background:

I didn't really make it work when I bumped the version of bignumber.js.
I bumped it because I thought the problem I saw was caused by
bignumber.js discrepancy.

It turned out the problem I had was require('bignumber.js') doesn't work
for es6 module 'bignumber.mjs'. I worked around it. Then I started seeing 
the API incompatibility issue. Hence this PR.